### PR TITLE
Update bbtoolbar.twig for follow core js modifications #16

### DIFF
--- a/Resources/views/partials/bbtoolbar.twig
+++ b/Resources/views/partials/bbtoolbar.twig
@@ -1,15 +1,7 @@
 
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/bootstrap.min.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/bb5-skin03.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/bootsrap-grid.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/bootsrap-resp-grid.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/jquery-ui.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/font-awesome.min.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/bootstrap.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/bb5-ui.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/font-awesome.css')) }}
+{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/bb-ui.css')) }}
+{{ this.addStylesheet(this.getResourceUrl('toolbar/bower_components/components-font-awesome/css/font-awesome.css')) }}
 {{ this.addStylesheet(this.getResourceUrl('toolbar/bower_components/datetimepicker/jquery.datetimepicker.css')) }}
-{{ this.addStylesheet(this.getResourceUrl('toolbar/html/css/fix.css')) }}
 
 {{ this.addHeaderJs(this.getResourceUrl('toolbar/bower_components/requirejs/require.js')) }}
 {{ this.addHeaderJs(this.getResourceUrl('toolbar/src/require.config.js')) }}


### PR DESCRIPTION
Remove off the useless css and add new toolbar css.

:warning: This PR have to be merged when after [CoreJs PR](https://github.com/backbee/BbCoreJs/pull/127).