### PR TITLE
added resource recipe to customize load of resources

### DIFF
--- a/Config/config.yml
+++ b/Config/config.yml
@@ -8,6 +8,7 @@ bundle:
     bundle_loader_recipes:
         helper: [BackBee\Bundle\ToolbarBundle\Toolbar, loadHelpers]
         template: [BackBee\Bundle\ToolbarBundle\Toolbar, loadTemplates]
+        resource: [BackBee\Bundle\ToolbarBundle\Toolbar, loadResources]
 
     ##
     # This part of config file is for debug the javascript

--- a/Config/services.yml
+++ b/Config/services.yml
@@ -2,6 +2,7 @@
 parameters:
     toolbar.bundle.controller.class: BackBee\Bundle\ToolbarBundle\Controller\ConfigController
     toolbar.bundle.plugin.manager.class: BackBee\Bundle\ToolbarBundle\Plugin\PluginManager
+    bbapp.resource.controller.class: BackBee\Bundle\ToolbarBundle\Controller\ResourceController
 
     error.base_folder: %bbapp.base.dir%/../toolbar-bundle/Resources/layouts/error/
     error.404: 'error.twig'

--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Bundle\ToolbarBundle\Controller;
+
+use BackBee\Controller\ResourceController as BackBeeResourceController;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+class ResourceController extends BackBeeResourceController
+{
+    /**
+     * {@inheritdoc}
+     *
+     * This method override BackBee\Controller\ResourceController::resourcesAction to handle toolbar/ resources.
+     */
+    public function resourcesAction($filename, $baseDir = null)
+    {
+        if (0 === strpos($filename, 'toolbar/')) {
+            $filename = substr($filename, 8);
+        }
+
+        return parent::resourcesAction($filename, $baseDir);
+    }
+}

--- a/Toolbar.php
+++ b/Toolbar.php
@@ -68,6 +68,23 @@ class Toolbar extends AbstractBundle
     }
 
     /**
+     * Loads ToolbarBundle and BBCoreJs resources directories into application.
+     *
+     * @param  BBApplication $application
+     * @param  Config        $config
+     */
+    public static function loadResources(BBApplication $application, Config $config)
+    {
+        $baseDir = $application->getContainer()->get('bundle.toolbar')->getBaseDirectory();
+        $application->addResourceDir($baseDir.DIRECTORY_SEPARATOR.'Resources');
+        $application->addResourceDir(implode(DIRECTORY_SEPARATOR, [
+            $application->getVendorDir(),
+            'backbee',
+            'bb-core-js',
+        ]));
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function start()


### PR DESCRIPTION
We want to stop to do mirror between ``repository/toolbar`` and ``vendor/backbee/bb-core-js`` folders. This PR brings change to keep it working even if there is not any rewrite rule to do so in apache2 or nginx.

ping @crouillon, @mickaelandrieu, @ndufreche.