### PR TITLE
Add DOM attribute data-base-toolbar

### DIFF
--- a/Resources/views/partials/bbtoolbar.twig
+++ b/Resources/views/partials/bbtoolbar.twig
@@ -16,6 +16,7 @@
 <div id="{{ wrapper }}"
     data-api="{{ this.getUri('/rest/2/') }}"
     data-base-url="{{ this.getUri('/') }}"
+    data-base-toolbar="{{ this.getResourceUrl('toolbar/') }}"
     data-toolbar-selector="true"
     {% if bb.token != null %}
         data-autostart


### PR DESCRIPTION
Having both data-base-url and data-base-toolbar allows to use CDN on static files for example but not on REST calls or services provided by BackBee
