### PR TITLE
[DROPZONE] #547 - enable user to drop blocks only in zones that can handle the right render mode

### DIFF
--- a/Renderer/Helper/bbcontent.php
+++ b/Renderer/Helper/bbcontent.php
@@ -134,8 +134,16 @@ class bbcontent extends AbstractHelper
         $this->computeDragAndDropAttributes();
         $this->computeIdentifierAttribute();
         $this->computeRendermodeAttribute();
+        $this->computeAcceptAttribute();
 
         return $this->getAttributesString();
+    }
+
+    public function computeAcceptAttribute()
+    {
+        if ($this->content instanceof ContentSet && 0 < count($this->content->getAccept())) {
+            $this->attributes['data-accept'] = implode(',', $this->content->getAccept());
+        }
     }
 
     public function computeRendermodeAttribute()


### PR DESCRIPTION
Add a data-accept attribute to managed contents on the page to allow the filtering of the drop zones according to the content type dragged.